### PR TITLE
move pack to correct folder if already existing but on different type (opt/start)

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -284,6 +284,7 @@ function! s:update_single_plugin(name, force) abort
       call s:echo_verbose(3, 'Cloning ' . a:name)
 
       let l:cmd = [g:minpac#opt.git, 'clone', '--quiet', l:url, l:dir]
+      let l:cmd += ['--recurse-submodules']
       if l:pluginfo.depth > 0
         let l:cmd += ['--depth=' . l:pluginfo.depth]
       endif

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -309,6 +309,7 @@ function! s:update_single_plugin(name, force) abort
     call s:echo_verbose(3, 'Updating ' . a:name)
     let l:pluginfo.revision = s:get_plugin_revision(a:name)
     let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet', '--ff-only']
+    let l:cmd += ['--recurse-submodules']
   endif
   return s:start_job(l:cmd, a:name, 0)
 endfunction


### PR DESCRIPTION
If a minpac#add() call was changed to use a pack inside 'opt' instead 'start' it was resulting in having 2 copies of the pack. With this patch it will simply be moved to the path specified.

The regex specifying the path to be substituted could catch false positives if g:minpac#opt.minpac_start_dir would contain multiple occurrences of '/start/' or '/opt/'.