### PR TITLE
Add nvim's remote plugins to 'rtp'

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -194,6 +194,11 @@ function! s:job_exit_cb(id, errcode, event) dict abort
 
         call s:generate_helptags(l:dir, 1)
 
+        if has('nvim') && isdirectory(l:dir . '/rplugin')
+          " Required for :UpdateRemotePlugins.
+          let &rtp += l:dir
+        endif
+
         call s:invoke_hook('post-update', [self.name], l:pluginfo.do)
       else
         " Even the plugin is not updated, generate helptags if it is not found.

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -196,7 +196,7 @@ function! s:job_exit_cb(id, errcode, event) dict abort
 
         if has('nvim') && isdirectory(l:dir . '/rplugin')
           " Required for :UpdateRemotePlugins.
-          let &rtp += l:dir
+          exec 'set rtp+=' . l:dir
         endif
 
         call s:invoke_hook('post-update', [self.name], l:pluginfo.do)


### PR DESCRIPTION
This is required when executing :UpdateRemotePlugins.
See #37.