### PR TITLE
Add minpac#status() function for showing status of plugins. #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ endif
 " information of plugins, then performs the task.
 command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
 command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
+command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
 ```
 
 Note that your .vimrc must be reloadable to use this. E.g.:
@@ -179,6 +180,9 @@ call minpac#update()
 
 " To uninstall unused plugins:
 call minpac#clean()
+
+" To see plugins s tatus:
+call minpac#status()
 ```
 
 
@@ -307,6 +311,13 @@ echo minpac#getpackages("minpac", "", "", 1)
 echo minpac#getpackages("", "NAME", "", 1)
 ```
 
+#### minpac#status()
+
+Print status of plugins in vertical split.
+
+When ran after `minpac#update()`, shows only installed and updated plugins.
+
+Otherwise, shows the status of the plugin and commits of last update (if any).
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ endif
 " Define user commands for updating/cleaning the plugins.
 " Each of them loads minpac, reloads .vimrc to register the
 " information of plugins, then performs the task.
-command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
+command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update() | call minpac#status()
 command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
 command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
 ```
@@ -181,7 +181,7 @@ call minpac#update()
 " To uninstall unused plugins:
 call minpac#clean()
 
-" To see plugins s tatus:
+" To see plugins status:
 call minpac#status()
 ```
 

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -460,23 +460,14 @@ function! minpac#impl#status()
             \ '--color=never', '--pretty=format:%h %s (%cr)', 'HEAD...HEAD@{1}'
             \ ])
 
-      let l:commits = filter(l:commits[1], {-> v:val !=? '' })
+      let l:plugin.lines = filter(l:commits[1], {-> v:val !=? '' })
 
-      " Show installed status only when the plugin is installed for the first time
-      if has_key(l:pluginfo, 'installed') && l:pluginfo.installed ==? 0
-        let l:plugin.status = 'Installed'
-      elseif !l:update_ran
+      if !l:update_ran
         let l:plugin.status = 'OK'
-      endif
-
-      " Fetching log on non-updated plugin returns fatal error, so make sure
-      " to handle that case properly
-      if len(l:commits) > 0 && l:commits[0] !~? 'fatal'
-        let l:plugin.lines = l:commits
-      endif
-
-      if get(l:pluginfo, 'revision') !=? '' && l:pluginfo.revision !=# s:get_plugin_revision(l:name)
+      elseif len(l:plugin.lines) > 0
         let l:plugin.status = 'Updated'
+      elseif has_key(l:pluginfo, 'installed') && l:pluginfo.installed ==? 0
+        let l:plugin.status = 'Installed'
       endif
     endif
 

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -427,13 +427,8 @@ function! minpac#impl#clean(args) abort
   endif
 endfunction
 
-function! minpac#impl#update_information() abort
-  let l:update_ran = exists('s:installed_plugins')
-  return {
-        \ 'update_ran': l:update_ran,
-        \ 'installed': l:update_ran ? s:installed_plugins : 0,
-        \ 'updated': l:update_ran ? s:updated_plugins : 0,
-        \ }
+function! minpac#impl#is_update_ran() abort
+  return exists('s:installed_plugins')
 endfunction
 
 " vim: set ts=8 sw=2 et:

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -456,9 +456,11 @@ function! minpac#impl#status()
     if !isdirectory(l:dir)
       let l:plugin.status = 'Not installed'
     else
-      let l:commits = systemlist([g:minpac#opt.git, '-C', l:dir, 'log',
+      let l:commits = s:system([g:minpac#opt.git, '-C', l:dir, 'log',
             \ '--color=never', '--pretty=format:%h %s (%cr)', 'HEAD...HEAD@{1}'
             \ ])
+
+      let l:commits = filter(l:commits[1], {-> v:val !=? '' })
 
       " Show installed status only when the plugin is installed for the first time
       if has_key(l:pluginfo, 'installed') && l:pluginfo.installed ==? 0

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -1,0 +1,134 @@
+let s:results = []
+
+function! minpac#status#get() abort
+  let l:update_info = minpac#impl#update_information()
+  let l:result = []
+  for l:name in keys(g:minpac#pluglist)
+    let l:pluginfo = g:minpac#pluglist[l:name]
+    let l:dir = l:pluginfo.dir
+    let l:plugin = { 'name': l:name, 'lines': [], 'status': '' }
+
+    if !isdirectory(l:dir)
+      let l:plugin.status = 'Not installed'
+    else
+      let l:commits = minpac#impl#system([g:minpac#opt.git, '-C', l:dir, 'log',
+            \ '--color=never', '--pretty=format:%h %s (%cr)', '--no-show-signature', 'HEAD...HEAD@{1}'
+            \ ])
+
+      let l:plugin.lines = filter(l:commits[1], {-> v:val !=? '' })
+
+      if !l:update_info.update_ran
+        let l:plugin.status = 'OK'
+      elseif get(l:pluginfo, 'revision') !=? '' && l:pluginfo.revision !=# minpac#impl#get_plugin_revision(l:name)
+        let l:plugin.status = 'Updated'
+      elseif has_key(l:pluginfo, 'installed') && l:pluginfo.installed ==? 0
+        let l:plugin.status = 'Installed'
+      endif
+    endif
+
+    call add(l:result, l:plugin)
+  endfor
+
+  " Show items with most lines (commits) first.
+  call sort(l:result, { first, second -> len(second.lines) - len(first.lines) })
+  let s:results = l:result
+
+  let l:content = []
+
+  if l:update_info.update_ran
+    call add(l:content, l:update_info.updated. ' updated. '.l:update_info.installed. ' installed.')
+  endif
+
+  for l:item in l:result
+    if l:item.status ==? ''
+      continue
+    endif
+
+    call add(l:content, '- '.l:item.name.' - '.l:item.status)
+    for l:line in l:item.lines
+      call add(l:content, ' * '.l:line)
+    endfor
+  endfor
+
+  let l:content = join(l:content, "\<NL>")
+  silent exe 'vertical topleft new'
+  setf minpac
+  silent exe 'put! =l:content|norm!gg'
+  call s:syntax()
+  call s:mappings()
+  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline nomodifiable nospell
+endfunction
+
+
+function! s:syntax() abort
+  syntax clear
+  syn match minpacDash /^-/
+  syn match minpacName /\(^- \)\@<=.*/ contains=minpacStatus
+  syn match minpacStatus /\(-.*\)\@<=-\s.*$/ contained
+  syn match minpacStar /^\s\*/ contained
+  syn match minpacCommit /^\s\*\s[0-9a-f]\{7,9} .*/ contains=minpacRelDate,minpacSha,minpacStar
+  syn match minpacSha /\(\s\*\s\)\@<=[0-9a-f]\{4,}/ contained
+  syn match minpacRelDate /([^)]*)$/ contained
+
+  hi def link minpacDash    Special
+  hi def link minpacStar    Boolean
+  hi def link minpacName    Function
+  hi def link minpacSha     Identifier
+  hi def link minpacRelDate Comment
+  hi def link minpacStatus  Constant
+endfunction
+
+function! s:mappings() abort
+  nnoremap <silent><buffer><CR> :call <SID>openSha()<CR>
+  nnoremap <silent><buffer>q :q<CR>
+  nnoremap <silent><buffer><C-j> :call <SID>nextPackage()<CR>
+  nnoremap <silent><buffer><C-k> :call <SID>prevPackage()<CR>
+endfunction
+
+function! s:nextPackage()
+  return search('^-\s.*$')
+endfunction
+
+function! s:prevPackage()
+  return search('^-\s.*$', 'b')
+endfunction
+
+function s:openSha() abort
+  let l:sha = matchstr(getline('.'), '^\s\*\s\zs[0-9a-f]\{7,9}')
+  if empty(l:sha)
+    return
+  endif
+
+  let l:name = s:find_name_by_sha(l:sha)
+
+  if empty(l:name)
+    return
+  endif
+
+  let l:pluginfo = g:minpac#pluglist[l:name]
+  exe 'pedit' l:sha
+  wincmd p
+  setlocal previewwindow filetype=git buftype=nofile nobuflisted modifiable
+  let l:sha_content = minpac#impl#system([g:minpac#opt.git, '-C', l:pluginfo.dir, 'show',
+            \ '--no-color', '--pretty=medium', l:sha
+            \ ])
+  let l:sha_content = join(l:sha_content[1], "\<NL>")
+
+  silent exe 'put! =l:sha_content|norm!gg'
+  setlocal nomodifiable
+  nnoremap <silent> <buffer> q :q<cr>
+endfunction
+
+function! s:find_name_by_sha(sha) abort
+  for l:result in s:results
+    for l:commit in l:result.lines
+      if l:commit =~? '^'.a:sha
+        return l:result.name
+      endif
+    endfor
+  endfor
+
+  return ''
+endfunction
+
+" vim: set ts=8 sw=2 et:

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -1,7 +1,9 @@
 let s:results = []
 
 function! minpac#status#get() abort
-  let l:update_info = minpac#impl#update_information()
+  let l:is_update_ran = minpac#impl#is_update_ran()
+  let l:update_count = 0
+  let l:install_count = 0
   let l:result = []
   for l:name in keys(g:minpac#pluglist)
     let l:pluginfo = g:minpac#pluglist[l:name]
@@ -17,11 +19,13 @@ function! minpac#status#get() abort
 
       let l:plugin.lines = filter(l:commits[1], {-> v:val !=? '' })
 
-      if !l:update_info.update_ran
+      if !l:is_update_ran
         let l:plugin.status = 'OK'
       elseif get(l:pluginfo, 'revision') !=? '' && l:pluginfo.revision !=# minpac#impl#get_plugin_revision(l:name)
+        let l:update_count += 1
         let l:plugin.status = 'Updated'
       elseif has_key(l:pluginfo, 'installed') && l:pluginfo.installed ==? 0
+        let l:install_count += 1
         let l:plugin.status = 'Installed'
       endif
     endif
@@ -35,8 +39,8 @@ function! minpac#status#get() abort
 
   let l:content = []
 
-  if l:update_info.update_ran
-    call add(l:content, l:update_info.updated. ' updated. '.l:update_info.installed. ' installed.')
+  if l:is_update_ran
+    call add(l:content, l:update_count.' updated. '.l:install_count.' installed.')
   endif
 
   for l:item in l:result

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -17,6 +17,7 @@ USAGE				|minpac-usage|
   COMMANDS			|minpac-commands|
   FUNCTIONS			|minpac-functions|
   HOOKS				|minpac-hooks|
+  MAPPINGS			|minpac-mappings|
 
 
 ==============================================================================
@@ -427,5 +428,22 @@ E.g.: >
 	" Quit Vim immediately after all updates are finished.
 	call minpac#update('', {'do': 'quit'})
 <
+------------------------------------------------------------------------------
+MAPPINGS						*minpac-mappings*
+
+List of mappings available only in status window.
+
+                                                *minpac-<CR>*
+<CR>                    Preview the commit under the cursor.
+
+                                                *minpac-CTRL-j*
+<C-j>                   Jump to next package in list.
+
+                                                *minpac-CTRL-k*
+<C-k>                   Jump to previous package in list.
+
+                                                *minpac-q*
+q                       Exit the status window.
+                        (Also works for commit preview window)
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -191,6 +191,9 @@ functions.  E.g.: >
 
 	" To uninstall unused plugins:
 	call minpac#clean()
+
+	" To see plugins status:
+	call minpac#status()
 <
 
 ------------------------------------------------------------------------------
@@ -343,6 +346,12 @@ minpac#getpackages([{packname}[, {packtype}[, {plugname}[, {nameonly}]]]])
 	" List package names.
 	echo minpac#getpackages("", "NAME", "", 1)
 <
+minpac#status()			              *minpac#status()*
+	Print status of plugins in vertical split.
+        When ran after `minpac#update()`, shows only installed and updated
+        plugins. Otherwise, shows the status of the plugin and commits of last
+        update (if any)
+
 ------------------------------------------------------------------------------
 HOOKS						*minpac-hooks*
 

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -166,7 +166,7 @@ Load minpac on demand
 	" Define user commands for updating/cleaning the plugins.
 	" Each of them loads minpac, reloads .vimrc to register the
 	" information of plugins, then performs the task.
-	command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
+	command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update() | call minpac#status()
 	command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
 <
   Note that your .vimrc must be reloadable to use this.  E.g.:

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -109,6 +109,11 @@ function! minpac#clean(...)
   return minpac#impl#clean(a:000)
 endfunction
 
+function! minpac#status()
+  call s:ensure_initialization()
+  return minpac#impl#status()
+endfunction
+
 
 " Get information of specified plugin. Mainly for debugging.
 function! minpac#getpluginfo(name)

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -111,7 +111,7 @@ endfunction
 
 function! minpac#status()
   call s:ensure_initialization()
-  return minpac#impl#status()
+  return minpac#status#get()
 endfunction
 
 


### PR DESCRIPTION
Initial version of status list.
Shows only installed/updated plugins after `minpac#update()` is called.
Otherwise, returns status of all plugins.
It works similar to vim-plug, but lot of feature are missing (commit preview, handling each commit separately, etc.)
This satisfies my requirement for now, and it can be extended later on.