### PR TITLE
Add submodule option

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Note: Unlike Vundle, a short form without `<github-account>/` is not supported. 
 | `'branch'` | Used as a branch name to be cloned. Only effective when install the plugin newly. Default: empty |
 | `'rev'`    | Commit ID, branch name or tag name to be checked out. If this is specified, `'depth'` will be ignored. Default: empty |
 | `'do'`     | Post-update hook. See [Post-update hooks](#post-update-hooks). Default: empty |
+| `'submodule'`| Install plugin as a *git submodule* |
 
 The `'branch'` and `'rev'` options are slightly different.  
 The `'branch'` option is used only when the plugin is newly installed. It clones the plugin by `git clone <URL> --depth=<DEPTH> -b <BRANCH>`. This is faster at the installation, but it can be slow if you want to change the branch (by the `'rev'` option) later. This cannot specify a commit ID.

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -388,8 +388,11 @@ function! s:update_single_plugin(name, force) abort
         let l:pluginfo.stat.upd_method = 2
       endif
       call s:echo_verbose(3, 'Cloning ' . a:name)
-
-      let l:cmd = [g:minpac#opt.git, 'clone', '--quiet', l:url, l:dir, '--no-single-branch']
+      if l:pluginfo.submodule 
+        let l:cmd = [g:minpac#opt.git, 'submodule', '--quiet', 'add', l:url, l:dir, '--no-single-branch']
+      else
+        let l:cmd = [g:minpac#opt.git, 'clone', '--quiet', l:url, l:dir, '--no-single-branch']
+      end
       if l:pluginfo.depth > 0 && l:pluginfo.rev ==# ''
         let l:cmd += ['--depth=' . l:pluginfo.depth]
       endif
@@ -422,7 +425,11 @@ function! s:update_single_plugin(name, force) abort
     elseif l:ret == 1
       " Same branch. Update by pull.
       call s:echo_verbose(3, 'Updating (pull): ' . a:name)
-      let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet', '--ff-only']
+      if l:pluginfo.submodule
+        let l:cmd = [g:minpac#opt.git, 'submodule', '--quiet', 'update', '--init', '--recursive', '--remote', l:dir]
+      else
+        let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet', '--ff-only']
+      endif
     elseif l:ret == 2
       " Different branch. Update by fetch & checkout.
       call s:echo_verbose(3, 'Updating (fetch): ' . a:name)

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -426,7 +426,8 @@ function! s:update_single_plugin(name, force) abort
       " Same branch. Update by pull.
       call s:echo_verbose(3, 'Updating (pull): ' . a:name)
       if l:pluginfo.submodule
-        let l:cmd = [g:minpac#opt.git, 'submodule', '--quiet', 'update', '--init', '--recursive', '--remote', l:dir]
+        let l:cmd = [g:minpac#opt.git, '-C', g:minpac#opt.minpac_dir,
+              \ 'submodule', '--quiet', 'update', '--init', '--recursive', '--remote', l:dir]
       else
         let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet', '--ff-only']
       endif

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -328,6 +328,7 @@ minpac#add({url}[, {config}])			*minpac#add()*
 		do		Post-update hook.
 				See |minpac-post-update-hooks|.
 				Default: empty
+		submodule	Install as a git submodule. Default: 0
 
 	The "branch" and "rev" options are slightly different.
 	The "branch" option is used only when the plugin is newly installed.

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -62,7 +62,7 @@ function! minpac#add(plugname, ...) abort
   call s:ensure_initialization()
   let l:opt = extend(copy(get(a:000, 0, {})),
         \ {'name': '', 'type': 'start', 'depth': g:minpac#opt.depth,
-        \  'frozen': 0, 'branch': '', 'rev': '', 'do': ''}, 'keep')
+        \  'frozen': 0, 'branch': '', 'rev': '', 'do': '', 'submodule': 0}, 'keep')
 
   " URL
   if a:plugname =~? '^[-._0-9a-z]\+\/[-._0-9a-z]\+$'


### PR DESCRIPTION
# Background
I and some vimmers managed own vimrc file with git repository. Then the user uses this plugin type the following commands to set up own vim.

```shell
$ git clone https://github.com/ta2gch/dot-vim ~/.config/nvim
$ git clone https://github.com/k-takata/minpac ~/.config/nvim/pack/minpac/opt/minpac
$ nvim -c ':call minpac#update()'
```

# My work
I propose you to add a new way add this plugin as a submodule to own repository managing my vimrc.
This request makes that commands be the followings.

```shell
$ git clone --recursive https://github.com/ta2gch/dot-vim ~/.config/nvim
$ # Don't need to install minpac, 
$ # because it is installed as a submodule by the previous command
$ nvim -c ':call minpac#update()'
```

# Difference from current vimrc

I added new option `'submodule'` which represents that it should be installed as a submodule.

```diff
- call minpack#add('t-takata/minpac', {'type':'opt'})
+ call minpack#add('t-takata/minpac', {'type':'opt', 'submodule': 1})
```

# Known issue

This request just works `minpac#add` and `minpac#update`, **not** `minpac#clean`.

Thank you!