### PR TITLE
Wait until all jobs done

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -514,6 +514,9 @@ function! minpac#impl#update(...) abort
   for l:name in l:names
     let ret = s:update_single_plugin(l:name, l:force)
   endfor
+  while s:remain_jobs > 0
+    sleep 500m
+  endwhile
 endfunction
 
 


### PR DESCRIPTION
Current implementation of minpac#impl#update(...) doesn't wait until all jobs finish.
This causes two malfunctions.
1. `Press ENTER or type command to continue` message is displayed during update and no this message when update done.

2. And when you automate minpac update like this:
`vim -EN -u .vimrc -s "+MinpacAddandUpdate" "+q"`
vim quits without all jobs done and some plugins aren't installed.
Also, even when you use `call minpac#update('', {'do': 'quit'})` with this automation like this:
`vim -EN -u .vimrc -s "+MinpacAddandUpdateandQuit"`
it fails since vim quits on its own and never waits the execution of '{'do': 'quit'}.'


This causes update automation impossible (please see my comment on https://github.com/k-takata/minpac/issues/83#issuecomment-526740762)