### PR TITLE
Let the site a short form URL gets expanded into be customised

### DIFF
--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -30,8 +30,25 @@ endfunction
 
 " Initialize minpac.
 function! minpac#init(...) abort
-  let l:opt = extend(copy(get(a:000, 0, {})),
-        \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1, 'jobs': 8, 'verbose': 2, 'status_open': 'vertical'}, 'keep')
+  let l:opt = extend(
+                      \ copy(get(a:000, 0, {})),
+                      \ {
+                          \ 'dir': '',
+                          \ 'package_name': 'minpac',
+                          \ 'git': 'git',
+                          \ 'depth': 1,
+                          \ 'jobs': 8,
+                          \ 'verbose': 2,
+                          \ 'status_open': 'vertical',
+                          \ 'site': 'github',
+                          \ 'sites': {
+                                         \ 'github': 'https://github.com/',
+                                         \ 'gitlab': 'https://gitlab.com/',
+                                         \ 'bitbucket': 'https://bitbucket.com/'
+                                     \ }
+                      \ },
+                      \ 'keep'
+                  \ )
 
   let g:minpac#opt = l:opt
   let g:minpac#pluglist = {}
@@ -60,13 +77,25 @@ endfunction
 " Register the specified plugin.
 function! minpac#add(plugname, ...) abort
   call s:ensure_initialization()
-  let l:opt = extend(copy(get(a:000, 0, {})),
-        \ {'name': '', 'type': 'start', 'depth': g:minpac#opt.depth,
-        \  'frozen': 0, 'branch': '', 'rev': '', 'do': ''}, 'keep')
+  let l:opt = extend(
+                      \ copy(get(a:000, 0, {})),
+                      \ {
+                         \ 'name': '',
+                         \ 'type': 'start',
+                         \ 'depth': g:minpac#opt.depth,
+                         \ 'frozen': 0,
+                         \ 'branch': '',
+                         \ 'rev': '',
+                         \ 'do': '',
+                         \ 'site': g:minpac#opt.site
+                      \ },
+                      \ 'keep'
+                  \ )
 
   " URL
   if a:plugname =~? '^[-._0-9a-z]\+\/[-._0-9a-z]\+$'
-    let l:opt.url = 'https://github.com/' . a:plugname . '.git'
+    let l:url = g:minpac#opt.sites[l:opt.site]
+    let l:opt.url = l:url . a:plugname . '.git'
   else
     let l:opt.url = a:plugname
   endif

--- a/test/test_minpac.vim
+++ b/test/test_minpac.vim
@@ -22,12 +22,14 @@ func Test_minpac_init()
   call assert_equal(8, g:minpac#opt.jobs)
   call assert_equal(2, g:minpac#opt.verbose)
   call assert_equal('vertical', g:minpac#opt.status_open)
+  call assert_equal('github', g:minpac#opt.site)
+  call assert_equal({'github': 'https://github.com/', 'gitlab': 'https://gitlab.com/', 'bitbucket': 'https://bitbucket.com/'}, g:minpac#opt.sites)
   call assert_equal({}, minpac#getpluglist())
 
   let g:minpac#pluglist.foo = 'bar'
 
   " Change settings
-  call minpac#init({'package_name': 'm', 'git': 'foo', 'depth': 10, 'jobs': 2, 'verbose': 1, 'status_open': 'horizontal'})
+  call minpac#init({'package_name': 'm', 'git': 'foo', 'depth': 10, 'jobs': 2, 'verbose': 1, 'status_open': 'horizontal', 'site': 'foohub', 'sites': {'foohub': 'https://foohub.com/'}})
   call assert_true(isdirectory('pack/m/start'))
   call assert_true(isdirectory('pack/m/opt'))
   call assert_equal('foo', g:minpac#opt.git)
@@ -35,6 +37,8 @@ func Test_minpac_init()
   call assert_equal(2, g:minpac#opt.jobs)
   call assert_equal(1, g:minpac#opt.verbose)
   call assert_equal('horizontal', g:minpac#opt.status_open)
+  call assert_equal('foohub', g:minpac#opt.site)
+  call assert_equal({'foohub': 'https://foohub.com/'}, g:minpac#opt.sites)
   call assert_equal({}, minpac#getpluglist())
 
   call delete('pack', 'rf')
@@ -69,6 +73,11 @@ func Test_minpac_add()
   call assert_equal(10, p.depth)
   call assert_equal('', p.do)
   call assert_equal('abcdef', p.rev)
+
+  " Different site
+  call minpac#add('k-takata/minpac', {'site': 'bitbucket'})
+  let p = minpac#getpluginfo('minpac')
+  call assert_equal('https://bitbucket.com/k-takata/minpac.git', p.url)
 
   " SSH URL
   call minpac#add('git@github.com:k-takata/minpac.git', {'name': 'm'})


### PR DESCRIPTION
### Overview

Right now if you want to use something other than GitHub over HTTPS to get plugins you need to specify the full URL; if you want to do this with more than one or two plugins it will get messy. This PR adds a two keys to the config dictionary for `minpac#init` and one key to the config for `minpac#add` that try to fix this problem. 

### Use cases

* Change all your plugins to update over SSH.
* Remove all long form urls and just pass an extra key to `minpac#add`, which makes for a cleaner vimrc/init.vim
* Future proofs the plugin; if the plugin ecosystem changes to no longer have most plugins on GitHub, no update to minpac is required to support it. 

### What's been added

The keys for `minpac#init` are `'site'` and `'sites'`. `'sites'` is a dictionary whose keys are short names for sites, and whose values are the base url for the corresponding site; the default names are include `'github'`, whose value is `'https://github.com/'`. See the code for the others.  `'site'` is a key from the `'sites'` dictionary, default `'github'`. This is used as the default site for short form URLs passed to `minpac#add`. 

The key for `minpac#add` is also a key from the `'sites'` dictionary, and overrides the value set by `minpac#init`. 

I've also added tests for the new configuration options.

### To-do

This will probably need documentation before it's merged. 