### PR TITLE
Implement progress window

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ endif
 " Define user commands for updating/cleaning the plugins.
 " Each of them loads minpac, reloads .vimrc to register the
 " information of plugins, then performs the task.
-command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update('', {'do': 'call minpac#status()'})
+command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
 command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
 command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
 ```
@@ -187,7 +187,7 @@ endfunction
 " Define user commands for updating/cleaning the plugins.
 " Each of them calls PackInit() to load minpac and register
 " the information of plugins, then performs the task.
-command! PackUpdate call PackInit() | call minpac#update('', {'do': 'call minpac#status()'})
+command! PackUpdate call PackInit() | call minpac#update()
 command! PackClean  call PackInit() | call minpac#clean()
 command! PackStatus call PackInit() | call minpac#status()
 ```
@@ -259,7 +259,9 @@ Initialize minpac.
 | `'depth'` | Default clone depth. Default: 1 |
 | `'jobs'`  | Maximum job numbers. If <= 0, unlimited. Default: 8 |
 | `'verbose'` | Verbosity level (0 to 4).<br/>0: Show only important messages.<br/>1: Show the result of each plugin.<br/>2: Show error messages from external commands.<br/>3: Show start/end messages for each plugin.<br/>4: Show debug messages.<br/>Default: 2 |
-| `'status_open'` | Default setting for the open option of `minpac#status()`. Default: `'vertical'` |
+| `'progress_open'` | Specify how to show the progress of `minpac#update()`.<br/>`'none'`: Do not open the progress window. (Compatible with minpac v2.0.x or earlier.)<br/>`'horizontal'`: Open the progress window by splitting horizontally.<br/>`'vertical'`: Open the progress window by splitting vertically.<br/>`'tab'`: Open the progress window in a new tab.<br/>Default: `'horizontal'` |
+| `'status_open'` | Default setting for the open option of `minpac#status()`. Default: `'horizontal'` |
+| `'status_auto'` | Specify whether the status window will open automatically after `minpac#update()` is finished.<br/>`v:true`: Open the status window automatically, when one or more plugins are updated, installed or errored.<br/>`v:false`: Do not open the status window automatically. (Compatible with minpac v2.0.x or earlier.)<br/>Default: `v:true` |
 
 All plugins will be installed under the following directories:
 
@@ -398,7 +400,7 @@ Otherwise, shows the status of the plugin and commits of last update (if any).
 
 | option   | description |
 |----------|-------------|
-| `'open'` | Specify how to open the status window.<br/>`'vertical'`: Open in vertical split.<br/>`'horizontal'`: Open in horizontal split.<br/>`'tab'`: Open in a new tab.<br/>Default: `'vertical'` or specified value by `minpac#init()`.  |
+| `'open'` | Specify how to open the status window.<br/>`'vertical'`: Open in vertical split.<br/>`'horizontal'`: Open in horizontal split.<br/>`'tab'`: Open in a new tab.<br/>Default: `'horizontal'` or specified value by `minpac#init()`.  |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -124,51 +124,20 @@ endif
 
 #### Load minpac on demand
 
-Very interestingly, minpac doesn't need to be loaded every time. Unlike other plugin managers, it is needed only when updating, installing or cleaning the plugins. This is because minpac itself doesn't handle the runtime path.
+Very interestingly, minpac doesn't need to be loaded every time when you execute Vim. Unlike other plugin managers, it is needed only when updating, installing or cleaning the plugins. This is because minpac itself doesn't handle the runtime path.
 
-You can define a user command to load minpac, reload .vimrc to register the information of plugins, then call `minpac#update()`, `minpac#clean()` or `minpac#status()`.
+You can define user commands to load minpac, register the information of plugins, then call `minpac#update()`, `minpac#clean()` or `minpac#status()`.
 
 ```vim
-" For a paranoia.
-" Normally `:set nocp` is not needed, because it is done automatically
-" when .vimrc is found.
+" Normally this if-block is not needed, because `:set nocp` is done
+" automatically when .vimrc is found. However, this might be useful
+" when you execute `vim -u .vimrc` from the command line.
 if &compatible
   " `:set nocp` has many side effects. Therefore this should be done
   " only when 'compatible' is set.
   set nocompatible
 endif
 
-if exists('*minpac#init')
-  " minpac is loaded.
-  call minpac#init()
-  call minpac#add('k-takata/minpac', {'type': 'opt'})
-
-  " Additional plugins here.
-  call minpac#add('vim-jp/syntax-vim-ex')
-  ...
-endif
-
-" Plugin settings here.
-...
-
-" Define user commands for updating/cleaning the plugins.
-" Each of them loads minpac, reloads .vimrc to register the
-" information of plugins, then performs the task.
-command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
-command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
-command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
-```
-
-Note that your .vimrc must be reloadable to use this. E.g.:
-
-* `:set nocompatible` should not be executed twice to avoid side effects.
-* `:function!` should be used to define a user function.
-* `:command!` should be used to define a user command.
-* `:augroup!` should be used properly to avoid the same autogroups are defined twice.
-
-Another way is defining a function to load minpac and register the information of plugins.
-
-```vim
 function! PackInit() abort
   packadd minpac
 
@@ -192,8 +161,20 @@ command! PackClean  call PackInit() | call minpac#clean()
 command! PackStatus call PackInit() | call minpac#status()
 ```
 
-This doesn't reload .vimrc, so the .vimrc doesn't need to be reloadable.
-However, if you make it reloadable, you can apply the changes to the .vimrc immediately by executing `:so $MYVIMRC | PackUpdate`.
+If you make your .vimrc reloadable, you can reflect the setting of the .vimrc immediately after you edit it by executing `:so $MYVIMRC | PackUpdate`. Or you can define the commands like this:
+
+```vim
+command! PackUpdate | source $MYVIMRC | call PackInit() | call minpac#update()
+command! PackClean  | source $MYVIMRC | call PackInit() | call minpac#clean()
+command! PackStatus | source $MYVIMRC | call PackInit() | call minpac#status()
+```
+
+To make your .vimrc reloadable:
+
+* `:set nocompatible` should not be executed twice to avoid side effects.
+* `:function!` should be used to define a user function.
+* `:command!` should be used to define a user command.
+* `:augroup!` should be used properly to avoid the same autogroups are defined twice.
 
 
 Sometimes, you may want to open a shell at the directory where a plugin is installed.  The following example defines a command to open a terminal window at the directory of a specified plugin.  (Requires Vim 8.0.902 or later.)

--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -1,0 +1,58 @@
+" ---------------------------------------------------------------------
+" minpac: A minimal package manager for Vim 8 (and Neovim)
+"
+" Maintainer:   Ken Takata
+" Last Change:  2020-01-27
+" License:      VIM License
+" URL:          https://github.com/k-takata/minpac
+" ---------------------------------------------------------------------
+
+let s:winid = 0
+
+" Add a message to the minpac progress window
+function! minpac#progress#add_msg(type, msg) abort
+  let l:wininfo = getwininfo(s:winid)
+  if l:wininfo == []
+    echom 'warning: minpac progress window not found.'
+    return
+  endif
+  " Goes to the minpac progress window.
+  exec l:wininfo[0].winnr . "wincmd w"
+  setlocal modifiable
+  let l:markers = {'': '  ', 'warning': 'W:', 'error': 'E:'}
+  call append(line('$') - 1, l:markers[a:type] . ' ' . a:msg)
+  setlocal nomodifiable
+endfunction
+
+" Open the minpac progress window
+function! minpac#progress#open(msg) abort
+  if g:minpac#opt.progress_open ==# 'vertical'
+    vertical topleft new
+  elseif g:minpac#opt.progress_open ==# 'horizontal'
+    topleft new
+  elseif g:minpac#opt.progress_open ==# 'tab'
+    tabnew
+  endif
+  let s:winid = win_getid()
+  call append(0, a:msg)
+
+  setf minpacprgs
+  call s:syntax()
+  call s:mappings()
+  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nomodifiable nospell
+endfunction
+
+function! s:syntax() abort
+  syntax clear
+  syn match minpacPrgsError /^E: .*/
+  syn match minpacPrgsWarning /^W: .*/
+
+  hi def link minpacPrgsError   ErrorMsg
+  hi def link minpacPrgsWarning WarningMsg
+endfunction
+
+function! s:mappings() abort
+  nnoremap <silent><buffer> q :q<CR>
+endfunction
+
+" vim: set ts=8 sw=2 et:

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -135,54 +135,22 @@ Advanced sample
 <
 Load minpac on demand
 
-  Very interestingly, minpac doesn't need to be loaded every time.  Unlike
-  other plugin managers, it is needed only when updating, installing or
-  cleaning the plugins.  This is because minpac itself doesn't handle the
-  runtime path.
+  Very interestingly, minpac doesn't need to be loaded every time when you
+  execute Vim.  Unlike other plugin managers, it is needed only when updating,
+  installing or cleaning the plugins.  This is because minpac itself doesn't
+  handle the runtime path.
 
-  You can define a user command to load minpac, reload .vimrc to register the
-  information of plugins, then call |minpac#update()|, |minpac#clean()| or
-  |minpac#status()|. >
-
-	" For a paranoia.
-	" Normally `:set nocp` is not needed, because it is done automatically
-	" when .vimrc is found.
+  You can define user commands to load minpac, register the information of
+  plugins, then call |minpac#update()|, |minpac#clean()| or |minpac#status()|.
+>
+	" Normally this if-block is not needed, because `:set nocp` is done
+	" automatically when .vimrc is found. However, this might be useful
+	" when you execute `vim -u .vimrc` from the command line.
 	if &compatible
 	  " `:set nocp` has many side effects. Therefore this should be done
 	  " only when 'compatible' is set.
 	  set nocompatible
 	endif
-
-	if exists('*minpac#init')
-	  " minpac is loaded.
-	  call minpac#init()
-	  call minpac#add('k-takata/minpac', {'type': 'opt'})
-
-	  " Additional plugins here.
-	  call minpac#add('vim-jp/syntax-vim-ex')
-	  ...
-	endif
-
-	" Plugin settings here.
-	...
-
-	" Define user commands for updating/cleaning the plugins.
-	" Each of them loads minpac, reloads .vimrc to register the
-	" information of plugins, then performs the task.
-	command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
-	command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
-	command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
-<
-  Note that your .vimrc must be reloadable to use this.  E.g.:
-
-  * `:set nocompatible` should not be executed twice to avoid side effects.
-  * `:function!` should be used to define a user function.
-  * `:command!` should be used to define a user command.
-  * `:augroup!` should be used properly to avoid the same autogroups are
-    defined twice.
-
-  Another way is defining a function to load minpac and register the
-  information of plugins. >
 
 	function! PackInit() abort
 	  packadd minpac
@@ -206,9 +174,21 @@ Load minpac on demand
 	command! PackClean  call PackInit() | call minpac#clean()
 	command! PackStatus call PackInit() | call minpac#status()
 <
-  This doesn't reload .vimrc, so the .vimrc doesn't need to be reloadable.
-  However, if you make it reloadable, you can apply the changes to the .vimrc
-  immediately by executing `:so $MYVIMRC | PackUpdate` .
+  If you make your .vimrc reloadable, you can reflect the setting of the
+  .vimrc immediately after you edit it by executing
+  `:so $MYVIMRC | PackUpdate`.  Or you can define the commands like this: >
+
+	command! PackUpdate | source $MYVIMRC | call PackInit() | call minpac#update()
+	command! PackClean  | source $MYVIMRC | call PackInit() | call minpac#clean()
+	command! PackStatus | source $MYVIMRC | call PackInit() | call minpac#status()
+<
+  To make your .vimrc reloadable:
+
+  * `:set nocompatible` should not be executed twice to avoid side effects.
+  * `:function!` should be used to define a user function.
+  * `:command!` should be used to define a user command.
+  * `:augroup!` should be used properly to avoid the same autogroups are
+    defined twice.
 
 
   Sometimes, you may want to open a shell at the directory where a plugin is

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -169,7 +169,7 @@ Load minpac on demand
 	" Define user commands for updating/cleaning the plugins.
 	" Each of them loads minpac, reloads .vimrc to register the
 	" information of plugins, then performs the task.
-	command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update('', {'do': 'call minpac#status()'})
+	command! PackUpdate packadd minpac | source $MYVIMRC | call minpac#update()
 	command! PackClean  packadd minpac | source $MYVIMRC | call minpac#clean()
 	command! PackStatus packadd minpac | source $MYVIMRC | call minpac#status()
 <
@@ -202,7 +202,7 @@ Load minpac on demand
 	" Define user commands for updating/cleaning the plugins.
 	" Each of them calls PackInit() to load minpac and register
 	" the information of plugins, then performs the task.
-	command! PackUpdate call PackInit() | call minpac#update('', {'do': 'call minpac#status()'})
+	command! PackUpdate call PackInit() | call minpac#update()
 	command! PackClean  call PackInit() | call minpac#clean()
 	command! PackStatus call PackInit() | call minpac#status()
 <
@@ -279,9 +279,29 @@ minpac#init([{config}])				*minpac#init()*
 				3: Show start/end messages for each plugin.
 				4: Show debug messages.
 				Default: 2
+		progress_open	Specify how to show the progress of
+				|minpac#update()|.
+				"none": Do not open the progress window.
+				  (Compatible with minpac v2.0.x or earlier.)
+				"horizontal": Open the progress window by
+				  splitting horizontally.
+				"vertical": Open the progress window by
+				  splitting vertically.
+				"tab": Open the progress window in a new tab.
+				Default: "horizontal"
 		status_open	Default setting for the open option of
 				|minpac#status()|.
-				Default: "vertical"
+				Default: "horizontal"
+		status_auto	Specify whether the status window will open
+				automatically after |minpac#update()| is
+				finished.
+				v:true: Open the status window automatically,
+				  when one or more plugins are updated,
+				  installed or errored.
+				v:false: Do not open the status window
+				  automatically. (Compatible with minpac
+				  v2.0.x or earlier.)
+				Default: v:true
 
 	All plugins will be installed under the following directories:
 
@@ -462,7 +482,7 @@ minpac#status([{config}])			*minpac#status()*
 				"vertical": Open in vertical split.
 				"horizontal": Open in horizontal split.
 				"tab": Open in a new tab.
-				Default: "vertical" or specified value by
+				Default: "horizontal" or specified value by
 				|minpac#init()|.
 
 ------------------------------------------------------------------------------

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -31,7 +31,7 @@ endfunction
 " Initialize minpac.
 function! minpac#init(...) abort
   let l:opt = extend(copy(get(a:000, 0, {})),
-        \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1, 'jobs': 8, 'verbose': 2, 'status_open': 'vertical'}, 'keep')
+        \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1, 'jobs': 8, 'verbose': 2, 'progress_open': 'horizontal', 'status_open': 'horizontal', 'status_auto': v:true}, 'keep')
 
   let g:minpac#opt = l:opt
   let g:minpac#pluglist = {}

--- a/test/test_minpac.vim
+++ b/test/test_minpac.vim
@@ -21,20 +21,24 @@ func Test_minpac_init()
   call assert_equal(1, g:minpac#opt.depth)
   call assert_equal(8, g:minpac#opt.jobs)
   call assert_equal(2, g:minpac#opt.verbose)
-  call assert_equal('vertical', g:minpac#opt.status_open)
+  call assert_equal('horizontal', g:minpac#opt.progress_open)
+  call assert_equal('horizontal', g:minpac#opt.status_open)
+  call assert_equal(v:true, g:minpac#opt.status_auto)
   call assert_equal({}, minpac#getpluglist())
 
   let g:minpac#pluglist.foo = 'bar'
 
   " Change settings
-  call minpac#init({'package_name': 'm', 'git': 'foo', 'depth': 10, 'jobs': 2, 'verbose': 1, 'status_open': 'horizontal'})
+  call minpac#init({'package_name': 'm', 'git': 'foo', 'depth': 10, 'jobs': 2, 'verbose': 1, 'progress_open': 'tab', 'status_open': 'vertical', 'status_auto': v:false})
   call assert_true(isdirectory('pack/m/start'))
   call assert_true(isdirectory('pack/m/opt'))
   call assert_equal('foo', g:minpac#opt.git)
   call assert_equal(10, g:minpac#opt.depth)
   call assert_equal(2, g:minpac#opt.jobs)
   call assert_equal(1, g:minpac#opt.verbose)
-  call assert_equal('horizontal', g:minpac#opt.status_open)
+  call assert_equal('tab', g:minpac#opt.progress_open)
+  call assert_equal('vertical', g:minpac#opt.status_open)
+  call assert_equal(v:false, g:minpac#opt.status_auto)
   call assert_equal({}, minpac#getpluglist())
 
   call delete('pack', 'rf')


### PR DESCRIPTION
Outputting the log messages by echo commands is sometimes not good especially when updating many plugins. It may mess the display.
Add a new option to output the log message to a separate window, and enable it by default.

This adds or changes the following options in `minpac#init()`:

* progress_open: Open the progress window if set to 'horizontal', 'vertical' or 'tab'.
* status_open: Changed the default from 'vertical' to 'horizontal'.
* status_auto: Open the status window automatically if set to v:true.

Note that these options change the default behavior from minpac v2.0.x or earlier.