### PR TITLE
Implement 'subdir' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Note: Unlike Vundle, a short form without `<github-account>/` is not supported. 
 | `'branch'` | Used as a branch name to be cloned. Only effective when install the plugin newly. Default: empty |
 | `'rev'`    | Commit ID, branch name or tag name to be checked out. If this is specified, `'depth'` will be ignored. Default: empty |
 | `'do'`     | Post-update hook. See [Post-update hooks](#post-update-hooks). Default: empty |
+| `'subdir'` | Subdirectory that contains Vim plugin. Default: empty |
 
 The `'branch'` and `'rev'` options are slightly different.  
 The `'branch'` option is used only when the plugin is newly installed. It clones the plugin by `git clone <URL> --depth=<DEPTH> -b <BRANCH>`. This is faster at the installation, but it can be slow if you want to change the branch (by the `'rev'` option) later. This cannot specify a commit ID.
@@ -279,6 +280,14 @@ The `'rev'` option is used both for installing and updating the plugin. It insta
 So, if you want to change the branch frequently or want to specify a commit ID, you should use the `'rev'` option. Otherwise you can use the `'branch'` option.
 
 If you include `*` in `'rev'`, minpac tries to checkout the latest tag name which matches the `'rev'`.
+
+When `'subdir'` is specified, the plugin will be installed as usual (e.g. in `pack/minpac/start/pluginname`), however, another directory is created and a symlink (or a junction on Windows) will be created in it. E.g.:
+
+```
+ln -s pack/minpac/start/pluginname/subdir pack/minpac-sub/start/pluginname
+```
+
+This way, Vim can load the plugin from its subdirectory.
 
 
 #### minpac#update([{name}[, {config}]])

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -327,6 +327,8 @@ minpac#add({url}[, {config}])			*minpac#add()*
 		do		Post-update hook.
 				See |minpac-post-update-hooks|.
 				Default: empty
+		subdir		Subdirectory that contains Vim plugin.
+				Default: empty
 
 	The "branch" and "rev" options are slightly different.
 	The "branch" option is used only when the plugin is newly installed.
@@ -345,6 +347,16 @@ minpac#add({url}[, {config}])			*minpac#add()*
 
 	If you include "*" in "rev", minpac tries to checkout the latest tag
 	name which matches the "rev".
+
+	When "subdir"" is specified, the plugin will be installed as usual
+	(e.g. in `pack/minpac/start/pluginname`), however, another directory
+	is created and a symlink (or a junction on Windows) will be created in
+	it. E.g.: >
+
+		ln -s pack/minpac/start/pluginname/subdir \
+		      pack/minpac-sub/start/pluginname
+
+<	This way, Vim can load the plugin from its subdirectory.
 
 
 minpac#update([{name}[, {config}]])			*minpac#update()*

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -31,7 +31,9 @@ endfunction
 " Initialize minpac.
 function! minpac#init(...) abort
   let l:opt = extend(copy(get(a:000, 0, {})),
-        \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1, 'jobs': 8, 'verbose': 2, 'progress_open': 'horizontal', 'status_open': 'horizontal', 'status_auto': v:false}, 'keep')
+        \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1,
+        \  'jobs': 8, 'verbose': 2, 'progress_open': 'horizontal',
+        \  'status_open': 'horizontal', 'status_auto': v:false}, 'keep')
 
   let g:minpac#opt = l:opt
   let g:minpac#pluglist = {}
@@ -41,9 +43,16 @@ function! minpac#init(...) abort
     " If 'dir' is not specified, the first directory of 'packpath' is used.
     let l:packdir = split(&packpath, ',')[0]
   endif
+
   let l:opt.minpac_dir = l:packdir . '/pack/' . l:opt.package_name
   let l:opt.minpac_start_dir = l:opt.minpac_dir . '/start'
   let l:opt.minpac_opt_dir = l:opt.minpac_dir . '/opt'
+
+  " directories for 'subdir'
+  let l:opt.minpac_dir_sub = l:packdir . '/pack/' . l:opt.package_name . '-sub'
+  let l:opt.minpac_start_dir_sub = l:opt.minpac_dir_sub . '/start'
+  let l:opt.minpac_opt_dir_sub = l:opt.minpac_dir_sub . '/opt'
+
   if !isdirectory(l:packdir)
     echoerr 'Pack directory not available: ' . l:packdir
     return
@@ -62,7 +71,8 @@ function! minpac#add(plugname, ...) abort
   call s:ensure_initialization()
   let l:opt = extend(copy(get(a:000, 0, {})),
         \ {'name': '', 'type': 'start', 'depth': g:minpac#opt.depth,
-        \  'frozen': 0, 'branch': '', 'rev': '', 'do': ''}, 'keep')
+        \  'frozen': 0, 'branch': '', 'rev': '', 'do': '', 'subdir': ''},
+        \ 'keep')
 
   " URL
   if a:plugname =~? '^[-._0-9a-z]\+\/[-._0-9a-z]\+$'

--- a/test/test_minpac.vim
+++ b/test/test_minpac.vim
@@ -61,9 +61,10 @@ func Test_minpac_add()
   call assert_equal(1, p.depth)
   call assert_equal('', p.do)
   call assert_equal('', p.rev)
+  call assert_equal('', p.subdir)
 
   " With configuration
-  call minpac#add('k-takata/minpac', {'type': 'opt', 'frozen': 1, 'branch': 'master', 'depth': 10, 'rev': 'abcdef'})
+  call minpac#add('k-takata/minpac', {'type': 'opt', 'frozen': 1, 'branch': 'master', 'depth': 10, 'rev': 'abcdef', 'subdir': 'dir'})
   let p = minpac#getpluginfo('minpac')
   call assert_equal('https://github.com/k-takata/minpac.git', p.url)
   call assert_match('/pack/minpac/opt/minpac$', p.dir)
@@ -73,6 +74,7 @@ func Test_minpac_add()
   call assert_equal(10, p.depth)
   call assert_equal('', p.do)
   call assert_equal('abcdef', p.rev)
+  call assert_equal('dir', p.subdir)
 
   " SSH URL
   call minpac#add('git@github.com:k-takata/minpac.git', {'name': 'm'})


### PR DESCRIPTION
Close #33.

When a plugin is registered with 'subdir' option, minpac will install it in:

	pack/minpac/start/pluginname

as usual, then create a symlink (or a junction on Windows):

	ln -s pack/minpac/start/pluginname/subdir \
	      pack/minpac-sub/start/pluginname