### PR TITLE
Make git operation faster

### DIFF
--- a/autoload/minpac/git.vim
+++ b/autoload/minpac/git.vim
@@ -1,0 +1,87 @@
+" ---------------------------------------------------------------------
+" minpac: A minimal package manager for Vim 8 (and Neovim)
+"
+" Maintainer:   Ken Takata
+" Last Change:  2020-01-31
+" License:      VIM License
+" URL:          https://github.com/k-takata/minpac
+" ---------------------------------------------------------------------
+
+function! s:isroot(dir) abort
+  if a:dir =~# '^/' || (has('win32') && a:dir =~? '^\%(\\\|[A-Z]:\)')
+    return v:true
+  endif
+  return v:false
+endfunction
+
+function! s:get_gitdir(dir) abort
+  let l:gitdir = a:dir . '/.git'
+  if isdirectory(l:gitdir)
+    return l:gitdir
+  elseif filereadable(l:gitdir)
+    try
+      let l:line = readfile(l:gitdir)[0]
+    catch
+      return ''
+    endtry
+    if l:line =~# '^gitdir: '
+      let l:dir = l:line[8:]
+      if s:isroot(l:dir)
+        let l:gitdir = l:dir
+      else
+        let l:gitdir = a:dir . '/' . l:dir
+      endif
+      if isdirectory(l:gitdir)
+        return l:gitdir
+      endif
+    endif
+  endif
+  return ''
+endfunction
+
+function! minpac#git#get_revision(dir) abort
+  let l:gitdir = s:get_gitdir(a:dir)
+  if l:gitdir ==# ''
+    return v:null
+  endif
+  try
+    let l:line = readfile(l:gitdir . '/HEAD')[0]
+    if l:line =~# '^ref: '
+      let l:ref = l:line[5:]
+      if filereadable(l:gitdir . '/' . l:ref)
+        let l:rev = readfile(l:gitdir . '/' . l:ref)[0]
+      else
+        let l:rev = v:null
+        for l:line in readfile(l:gitdir . '/packed-refs')
+          if l:line =~# ' ' . l:ref
+            let l:rev = substitute(l:line, '^\([0-9a-f]*\) ', '\1', '')
+            break
+          endif
+        endfor
+      endif
+    else
+      let l:rev = l:line
+    endif
+    return l:rev
+  catch
+    return v:null
+  endtry
+endfunction
+
+function! minpac#git#get_branch(dir) abort
+  let l:gitdir = s:get_gitdir(a:dir)
+  if l:gitdir ==# ''
+    return v:null
+  endif
+  try
+    let l:line = readfile(l:gitdir . '/HEAD')[0]
+    if l:line =~# '^ref: refs/heads/'
+      return l:line[16:]
+    endif
+    return ''
+  catch
+    return v:null
+  endtry
+endfunction
+
+" vim: set ts=8 sw=2 et:

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -111,6 +111,11 @@ endfunction
 
 " Get the revision of the specified plugin.
 function! minpac#impl#get_plugin_revision(name) abort
+  let l:rev = minpac#git#get_revision(g:minpac#pluglist[a:name].dir)
+  if l:rev != v:null
+    call s:echom_verbose(4, '', 'revision: ' . l:rev)
+    return l:rev
+  endif
   return s:exec_plugin_cmd(a:name, ['rev-parse', 'HEAD'], 'revision')
 endfunction
 
@@ -126,6 +131,11 @@ endfunction
 
 " Get the branch name of the specified plugin.
 function! s:get_plugin_branch(name) abort
+  let l:branch = minpac#git#get_branch(g:minpac#pluglist[a:name].dir)
+  if l:branch != v:null
+    call s:echom_verbose(4, '', 'branch: ' . l:branch)
+    return l:branch
+  endif
   return s:exec_plugin_cmd(a:name, ['symbolic-ref', '--short', 'HEAD'], 'branch')
 endfunction
 


### PR DESCRIPTION
Executing external programs is slow especially on Windows.
Read the information directly from .git directory.