### PR TITLE
Add 'pullmethod' option to minpac#add()

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Note: Unlike Vundle, a short form without `<github-account>/` is not supported. 
 | `'rev'`    | Commit ID, branch name or tag name to be checked out. If this is specified, `'depth'` will be ignored. Default: empty |
 | `'do'`     | Post-update hook. See [Post-update hooks](#post-update-hooks). Default: empty |
 | `'subdir'` | Subdirectory that contains Vim plugin. Default: empty |
+| `'pullmethod'` | Specify how to update the plugin.<br/>Empty: Update with `--ff-only` option.<br/>`'autostash'`: Update with `--rebase --autostash` options.<br/>Default: empty |
 
 The `'branch'` and `'rev'` options are slightly different.  
 The `'branch'` option is used only when the plugin is newly installed. It clones the plugin by `git clone <URL> --depth=<DEPTH> -b <BRANCH>`. This is faster at the installation, but it can be slow if you want to change the branch (by the `'rev'` option) later. This cannot specify a commit ID.

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -538,7 +538,12 @@ function! s:update_single_plugin(name, force) abort
     elseif l:ret == 1
       " Same branch. Update by pull.
       call s:echo_verbose(3, '', 'Updating (pull): ' . a:name)
-      let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet', '--ff-only', '--rebase=false']
+      let l:cmd = [g:minpac#opt.git, '-C', l:dir, 'pull', '--quiet']
+      if l:pluginfo.pullmethod ==# 'autostash'
+        let l:cmd += ['--rebase', '--autostash']
+      else
+        let l:cmd += ['--ff-only', '--rebase=false']
+      endif
     elseif l:ret == 2
       " Different branch. Update by fetch & checkout.
       call s:echo_verbose(3, '', 'Updating (fetch): ' . a:name)

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -340,6 +340,11 @@ minpac#add({url}[, {config}])			*minpac#add()*
 				Default: empty
 		subdir		Subdirectory that contains Vim plugin.
 				Default: empty
+		pullmethod	Specify how to update the plugin.
+				Empty: Update with `--ff-only` option.
+				"autostash": Update with `--rebase --autostash`
+				options.
+				Default: empty
 
 	The "branch" and "rev" options are slightly different.
 	The "branch" option is used only when the plugin is newly installed.

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -71,8 +71,9 @@ function! minpac#add(plugname, ...) abort
   call s:ensure_initialization()
   let l:opt = extend(copy(get(a:000, 0, {})),
         \ {'name': '', 'type': 'start', 'depth': g:minpac#opt.depth,
-        \  'frozen': v:false, 'branch': '', 'rev': '', 'do': '', 'subdir': ''},
-        \ 'keep')
+        \  'frozen': v:false, 'branch': '', 'rev': '', 'do': '', 'subdir': '',
+        \  'pullmethod': ''
+        \ }, 'keep')
 
   " URL
   if a:plugname =~? '^[-._0-9a-z]\+\/[-._0-9a-z]\+$'
@@ -97,7 +98,13 @@ function! minpac#add(plugname, ...) abort
   elseif l:opt.type ==# 'opt'
     let l:opt.dir = g:minpac#opt.minpac_opt_dir . '/' . l:opt.name
   else
-    echoerr "Wrong type (must be 'start' or 'opt'): " . l:opt.type
+    echoerr a:plugname . ": Wrong type (must be 'start' or 'opt'): " . l:opt.type
+    return
+  endif
+
+  " Check pullmethod
+  if l:opt.pullmethod !=# '' && l:opt.pullmethod !=# 'autostash'
+    echoerr a:plugname . ": Wrong pullmethod (must be empty or 'autostash'): " . l:opt.pullmethod
     return
   endif
 

--- a/test/test_minpac.vim
+++ b/test/test_minpac.vim
@@ -62,9 +62,10 @@ func Test_minpac_add()
   call assert_equal('', p.do)
   call assert_equal('', p.rev)
   call assert_equal('', p.subdir)
+  call assert_equal('', p.pullmethod)
 
   " With configuration
-  call minpac#add('k-takata/minpac', {'type': 'opt', 'frozen': v:true, 'branch': 'master', 'depth': 10, 'rev': 'abcdef', 'subdir': 'dir'})
+  call minpac#add('k-takata/minpac', {'type': 'opt', 'frozen': v:true, 'branch': 'master', 'depth': 10, 'rev': 'abcdef', 'subdir': 'dir', 'pullmethod': 'autostash'})
   let p = minpac#getpluginfo('minpac')
   call assert_equal('https://github.com/k-takata/minpac.git', p.url)
   call assert_match('/pack/minpac/opt/minpac$', p.dir)
@@ -75,6 +76,7 @@ func Test_minpac_add()
   call assert_equal('', p.do)
   call assert_equal('abcdef', p.rev)
   call assert_equal('dir', p.subdir)
+  call assert_equal('autostash', p.pullmethod)
 
   " SSH URL
   call minpac#add('git@github.com:k-takata/minpac.git', {'name': 'm'})


### PR DESCRIPTION
Close #81.

If 'pullmethod' is set to 'autostash', `--rebase --autostash` options
are used for `git pull`.