### PR TITLE
clean: support skipping the input() prompt

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -673,7 +673,8 @@ function! minpac#impl#clean(...) abort
   endfor
 
   let l:dir = (len(l:to_remove) > 1) ? 'directories' : 'directory'
-  if input('Removing the above ' . l:dir . '. [y/N]? ') =~? '^y'
+
+  if !g:minpac#opt.confirm || input('Removing the above ' . l:dir . '. [y/N]? ') =~? '^y'
     echo "\n"
     let err = 0
     for l:item in l:to_remove

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -270,6 +270,9 @@ minpac#init([{config}])				*minpac#init()*
 				3: Show start/end messages for each plugin.
 				4: Show debug messages.
 				Default: 2
+		confirm		Show interactive confirmation prompts, such as
+				in |minpac#clean()|.
+				Default: |TRUE|
 		progress_open	Specify how to show the progress of
 				|minpac#update()|.
 				"none": Do not open the progress window.
@@ -407,15 +410,16 @@ minpac#clean([{name}])				*minpac#clean()*
 
 	{name} is a name of a plugin.  It can be a unique plugin name
 	(|minpac-plugin_name|) or a plugin name with wildcards ("*" and "?"
-	are supported).
+	are supported). It can also be a list of plugin names.
 
 	If {name} is omitted, all plugins under the minpac directory will be
 	checked.  If unregistered plugins are found, they are listed and a
 	prompt is shown.  If you type "y", they will be removed.
 
-	If {name} is specified, matched plugins are listed (even they are
-	registered with |minpac#add()|) and a prompt is shown.  If you type
-	"y", they will be removed.  {name} can also be a list of plugin names.
+	When called, matched plugins are listed (even they are registered with
+	|minpac#add()|) and a prompt is shown.  If you type "y", they will be
+	removed.  If the 'confirm' option is not |TRUE|, the prompt will not
+	be shown.
 
 
 minpac#getpluginfo({name})			*minpac#getpluginfo()*

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -32,8 +32,9 @@ endfunction
 function! minpac#init(...) abort
   let l:opt = extend(copy(get(a:000, 0, {})),
         \ {'dir': '', 'package_name': 'minpac', 'git': 'git', 'depth': 1,
-        \  'jobs': 8, 'verbose': 2, 'progress_open': 'horizontal',
-        \  'status_open': 'horizontal', 'status_auto': v:false}, 'keep')
+        \  'jobs': 8, 'verbose': 2, 'confirm': v:true,
+        \  'progress_open': 'horizontal', 'status_open': 'horizontal',
+        \  'status_auto': v:false}, 'keep')
 
   let g:minpac#opt = l:opt
   let g:minpac#pluglist = {}


### PR DESCRIPTION
This is implemented as a new option, 'confirm', provided to
`minpac#init()`. The default behaviour has not changed.