### PR TITLE
Supply first argument to bufnr()

### DIFF
--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -46,7 +46,7 @@ function! minpac#progress#open(msg) abort
   call s:mappings()
   setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nomodifiable nospell
   exec "silent file" l:bufname
-  let s:bufnr = bufnr()
+  let s:bufnr = bufnr('')
 endfunction
 
 function! s:syntax() abort

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -111,7 +111,7 @@ function! minpac#status#get(opt) abort
   call s:mappings()
   setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline nomodifiable nospell
   exec "silent file" l:bufname
-  let s:bufnr = bufnr()
+  let s:bufnr = bufnr('')
 endfunction
 
 


### PR DESCRIPTION
Current minpac code does not supply the first argument when calling Vim’s `bufnr()` function. This argument [only became optional recently](https://github.com/vim/vim/commit/a8eee21e75324d199acb1663cb5009e03014a13a).

The problem manifests in the message `E119: Not enough arguments for function: bufnr` when calling for example `minpac#update()` (at `minpac#update[2]..minpac#impl#update[2]..minpac#progress#open`) or `minpac#status()` (at `minpac#status[4]..minpac#status#get`).

According to `:h patches-8` (in Vim), the argument to `bufnr()` can be optional since Vim 8.1.1924 (which is [included in NeoVim since 0.4.0](https://github.com/neovim/neovim/commit/66c06dad62638106fadad389f585dc11f482c6b1)), but on versions older than that, you have to supply an empty string as the first parameter instead. The current 3.0.0 version of minpac will not work on these older versions, which are still in widespread use (e.g. in Debian).

This pull request supplies a first argument of `''` in all two calls to `bufnr()`, instead of calling it without arguments.