### PR TITLE
Use timer to call s:update_single_plugin()

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -569,6 +569,12 @@ function! s:update_single_plugin(name, force) abort
   return s:start_job(l:cmd, a:name, 0)
 endfunction
 
+function! s:start_update(names, force, id) abort
+  for l:name in a:names
+    call s:update_single_plugin(l:name, a:force)
+  endfor
+endfunction
+
 " Update all or specified plugin(s).
 function! minpac#impl#update(...) abort
   if g:minpac#opt.progress_open !=# 'none'
@@ -609,11 +615,7 @@ function! minpac#impl#update(...) abort
     set nomore
   endif
 
-  for l:name in l:names
-    call timer_start(1, function(
-          \ {name, force, id -> s:update_single_plugin(name, force)},
-          \   [l:name, l:force]))
-  endfor
+  call timer_start(1, function('s:start_update', [l:names, l:force]))
 endfunction
 
 

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -610,7 +610,9 @@ function! minpac#impl#update(...) abort
   endif
 
   for l:name in l:names
-    let ret = s:update_single_plugin(l:name, l:force)
+    call timer_start(1, function(
+          \ {name, force, id -> s:update_single_plugin(name, force)},
+          \   [l:name, l:force]))
   endfor
 endfunction
 


### PR DESCRIPTION
See: #108

If a user has many plugins, minpac#update() may take a long time.
Use timer in it to call a subfunction.