### PR TITLE
Use exists('g:loaded_minpac') instead in docs

### DIFF
--- a/autoload/minpac.vim
+++ b/autoload/minpac.vim
@@ -7,12 +7,6 @@
 " URL:          https://github.com/k-takata/minpac
 " ---------------------------------------------------------------------
 
-if exists('g:loaded_minpac')
-  finish
-endif
-let g:loaded_minpac = 1
-
-
 " Get a list of package/plugin directories.
 function! minpac#getpackages(...)
   return call("minpac#impl#getpackages", a:000)

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -131,7 +131,7 @@ Advanced sample
 	" Try to load minpac.
 	packadd minpac
 
-	if !exists('*minpac#init')
+	if !exists('g:loaded_minpac')
 	  " minpac is not available.
 
 	  " Settings for plugin-less environment.

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -1,0 +1,13 @@
+" ---------------------------------------------------------------------
+" minpac: A minimal package manager for Vim 8 (and Neovim)
+"
+" Maintainer:   Ken Takata
+" Last Change:  2020-08-22
+" License:      VIM License
+" URL:          https://github.com/k-takata/minpac
+" ---------------------------------------------------------------------
+
+if exists('g:loaded_minpac')
+  finish
+endif
+let g:loaded_minpac = 1


### PR DESCRIPTION
From #114, the tips on docs does not work because exists() always return 0
for autoload function until initial call.
This commit add plugin/minpac.vim which just define 'g:loaded_minpac' and
rewrite document to use that.