### PR TITLE
Fix issues with sourcing plugins

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -265,11 +265,8 @@ else
 endif
 
 function! s:handle_subdir(pluginfo) abort
-  if a:pluginfo.type ==# 'start'
-    let l:workdir = g:minpac#opt.minpac_start_dir_sub
-  else
-    let l:workdir = g:minpac#opt.minpac_opt_dir_sub
-  endif
+  let l:workdir = g:minpac#opt.minpac_opt_dir_sub
+
   if !isdirectory(l:workdir)
     call mkdir(l:workdir, 'p')
   endif
@@ -353,11 +350,6 @@ function! s:job_exit_cb(id, errcode, event) dict abort
 
         if l:pluginfo.subdir !=# ''
           call s:handle_subdir(l:pluginfo)
-        endif
-
-        if has('nvim') && isdirectory(l:dir . '/rplugin')
-          " Required for :UpdateRemotePlugins.
-          call s:add_rtp(l:dir)
         endif
 
         call s:invoke_hook('post-update', [self.name], l:pluginfo.do)
@@ -474,7 +466,7 @@ endfunction
 function! s:prepare_plugin_dir(pluginfo) abort
   let l:dir = a:pluginfo.dir
   if !isdirectory(l:dir)
-    if a:pluginfo.type ==# 'start'
+    if l:dir =~# '/start/'
       let l:dirtmp = substitute(l:dir, '/start/\ze[^/]\+$', '/opt/', '')
     else
       let l:dirtmp = substitute(l:dir, '/opt/\ze[^/]\+$', '/start/', '')
@@ -488,7 +480,7 @@ function! s:prepare_plugin_dir(pluginfo) abort
   " Check subdir.
   if a:pluginfo.subdir !=# ''
     let l:name = a:pluginfo.name
-    if a:pluginfo.type ==# 'start'
+    if a:pluginfo.subdir =~# g:minpac#opt.minpac_start_dir_sub
       let l:subdir = g:minpac#opt.minpac_start_dir_sub . '/' . l:name
       let l:otherdir = g:minpac#opt.minpac_opt_dir_sub . '/' . l:name
     else


### PR DESCRIPTION
I'm author of vim-polyglot plugin which as very specific requirements when it comes about source files of plugins. Specifically it is required that its filetype script is loaded before vim's filetype script. Also the order of loading packages is important, vim-polyglot should defined first in ~/.vimrc, and should also be loaded first, before any other plugins. Consider `~/.vimrc` that defines 2 plugins to load. Every other package manager sources files in this order:

1. ftdetect dirs of plugins
2. ftdetect dir of vim runtime 
3. plugin dirs of vim plugins
4. plugin dir of vim runtime

You can see it in action for [vim-plug](https://gist.github.com/sheerun/8cc73588fc38b1b5fa67294fe3340789) ([vundle](https://gist.github.com/sheerun/c6465875cef9642df2117732778d4bf1), pathogen, dein.vim work the same). The same story is even with [vim8 packages when using start plugins + packload](https://gist.github.com/sheerun/c3d110fef5ed8a58ac4375167f3589b6) (here plugin load order depends on names of plugins), and also [vim8 opt packages + packadd command](https://gist.github.com/sheerun/8e5e82e7bd6b90366bd374e64db16324) (though here filetype.vim is loaded in reversed order...).

Here finally we can compare with [what minpac does](https://gist.github.com/sheerun/d1071155bd99a9f717746b31cb7df96b). First of all load order is different on vim and nvim, and it is wrong in both cases.

Vim load order:

1. ftdetect files of plugins (in reverse alphabetical order, instead of order of definition)
2. plugin dir of vim runtime
3. filetype.vim dir of vim runtime
4. plugin dirs of vim plugins, in reverse order

Nvim load order (even worse):

1. filetype.vim of vim runtime
2. plugin dir of vim runtime
3. ftdetect  files of plugins (but this time in alphabetical order, instead of order of definition)
4. runtime ftdetect files again
5 plugin dir of vim plugins

As you can see nothing is consistent and this PR changes it by loading plugins in correct order, on all platforms, in correct time, as other plugin managers do, and exactly the same on vim and nvim. I'm doing to by installing all packages as opt, and manually adding them to runtimepath, instead of either calling packadd, packadd!, packload, all of which have weird behaviors.