### PR TITLE
Use win_gotoid() to go to progress window

### DIFF
--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -12,13 +12,11 @@ let s:bufnr = 0
 
 " Add a message to the minpac progress window
 function! minpac#progress#add_msg(type, msg) abort
-  let l:wininfo = getwininfo(s:winid)
-  if l:wininfo == []
+  " Goes to the minpac progress window.
+  if !win_gotoid(s:winid)
     echom 'warning: minpac progress window not found.'
     return
   endif
-  " Goes to the minpac progress window.
-  exec l:wininfo[0].winnr . "wincmd w"
   setlocal modifiable
   let l:markers = {'': '  ', 'warning': 'W:', 'error': 'E:'}
   call append(line('$') - 1, l:markers[a:type] . ' ' . a:msg)


### PR DESCRIPTION
This is a bug fix.
Currently `wincmd w` is used to switch to progress window. This fails if the user has already switched to another tab, resulting in log messages being added to a wrong window. Must use `win_gotoid()` instead.