### PR TITLE
Remove single quotes from debug messages

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -43,7 +43,7 @@ function! s:echox_verbose(level, echocmd, type, msg) abort
       elseif a:type ==# 'error'
         echohl ErrorMsg
       endif
-      exec a:echocmd . " '" . a:msg . "'"
+      exec a:echocmd . " '" . substitute(a:msg, "'", "", "g") . "'"
       echohl None
     else
       call minpac#progress#add_msg(a:type, a:msg)

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -43,7 +43,7 @@ function! s:echox_verbose(level, echocmd, type, msg) abort
       elseif a:type ==# 'error'
         echohl ErrorMsg
       endif
-      exec a:echocmd . " '" . substitute(a:msg, "'", "", "g") . "'"
+      exec a:echocmd . " '" . substitute(a:msg, "'", "''", "g") . "'"
       echohl None
     else
       call minpac#progress#add_msg(a:type, a:msg)


### PR DESCRIPTION
Occasionally, messages are printed by minpac using `s:echox_verbose()`
that contain single quotes.  When this happens, it causes the following vim error:

`
Error detected while processing function <SNR>11_start_update[2]..
<SNR>11_update_single_plugin[62]..<SNR>11_start_job[6]..<SNR>94_on_stderr[4]..
<SNR>11_job_err_cb[9]..<SNR>11_echom_verbose[1]..<SNR>11_echox_verbose:
line    8:
E121: Undefined variable: master
` 

This happens because "master" is wrapped in single quotes.
Removing the single quotes fixes this issue.