### PR TITLE
Avoid wildcard expansion

### DIFF
--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -43,7 +43,7 @@ function! minpac#progress#open(msg) abort
   call s:syntax()
   call s:mappings()
   setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nomodifiable nospell
-  exec "silent file" l:bufname
+  silent file `=l:bufname`
   let s:bufnr = bufnr('')
 endfunction
 

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -110,7 +110,7 @@ function! minpac#status#get(opt) abort
   call s:syntax()
   call s:mappings()
   setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline nomodifiable nospell
-  exec "silent file" l:bufname
+  silent file `=l:bufname`
   let s:bufnr = bufnr('')
 endfunction
 


### PR DESCRIPTION
Fix #123.
The buffer name `[minpac progress]` can be handled as a wildcard.
Use "`=" to avoid it.