### PR TITLE
PackStatus is not useful without calling PackInit

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ endfunction
 " the information of plugins, then performs the task.
 command! PackUpdate call PackInit() | call minpac#update()
 command! PackClean  call PackInit() | call minpac#clean()
-command! PackStatus packadd minpac | call minpac#status()
+command! PackStatus call PackInit() | call minpac#status()
 ```
 
 If you make your .vimrc reloadable, you can reflect the setting of the .vimrc immediately after you edit it by executing `:so $MYVIMRC | PackUpdate`. Or you can define the commands like this:
@@ -172,7 +172,7 @@ If you make your .vimrc reloadable, you can reflect the setting of the .vimrc im
 ```vim
 command! PackUpdate source $MYVIMRC | call PackInit() | call minpac#update()
 command! PackClean  source $MYVIMRC | call PackInit() | call minpac#clean()
-command! PackStatus packadd minpac | call minpac#status()
+command! PackStatus call PackInit() | call minpac#status()
 ```
 
 To make your .vimrc reloadable:

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -181,7 +181,7 @@ Load minpac on demand
 	" the information of plugins, then performs the task.
 	command! PackUpdate call PackInit() | call minpac#update()
 	command! PackClean  call PackInit() | call minpac#clean()
-	command! PackStatus packadd minpac | call minpac#status()
+	command! PackStatus call PackInit() | call minpac#status()
 <
   If you make your .vimrc reloadable, you can reflect the setting of the
   .vimrc immediately after you edit it by executing
@@ -189,7 +189,7 @@ Load minpac on demand
 
 	command! PackUpdate source $MYVIMRC | call PackInit() | call minpac#update()
 	command! PackClean  source $MYVIMRC | call PackInit() | call minpac#clean()
-	command! PackStatus packadd minpac | call minpac#status()
+	command! PackStatus call PackInit() | call minpac#status()
 <
   To make your .vimrc reloadable:
 


### PR DESCRIPTION
Following the instructions for loading minpac on demand, calling
PackStatus as suggested results in the error message "Minpac has not
been initialized. Use the default values.".

It seems that for PackStatus to be useful, in the same way as PackUpdate
and PackClean, PackInit should be called first.