### PR TITLE
Fix that Vim is blocked when more than 8 plugins are registered

### DIFF
--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -401,14 +401,16 @@ function! s:job_err_cb(id, message, event) dict abort
   endfor
 endfunction
 
-function! s:start_job(cmds, name, seq) abort
+function! s:start_job(cmds, name, seq, ...) abort
   if len(s:joblist) > 1
     sleep 20m
   endif
   if g:minpac#opt.jobs > 0
-    while len(s:joblist) >= g:minpac#opt.jobs
-      sleep 500m
-    endwhile
+    if len(s:joblist) >= g:minpac#opt.jobs
+      " Call myself with a 500 ms wait.
+      call timer_start(500, function('s:start_job', [a:cmds, a:name, a:seq]))
+      return 0
+    endif
   endif
 
   let l:quote_cmds = s:quote_cmds(a:cmds)

--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -21,6 +21,7 @@ function! minpac#progress#add_msg(type, msg) abort
   let l:markers = {'': '  ', 'warning': 'W:', 'error': 'E:'}
   call append(line('$') - 1, l:markers[a:type] . ' ' . a:msg)
   setlocal nomodifiable
+  redraw
 endfunction
 
 " Open the minpac progress window


### PR DESCRIPTION
Fix #108.

Don't use `sleep` to wait jobs.
Also use `redraw` to update the progress window timely.