### PR TITLE
doc: Change 'quit' to 'qall'

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ E.g.:
 
 ```vim
 " Quit Vim immediately after all updates are finished.
-call minpac#update('', {'do': 'quit'})
+call minpac#update('', {'do': 'qall'})
 ```
 
 ### Mappings

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -570,7 +570,7 @@ If a Funcref is specified, it is called with three arguments; {hooktype},
 E.g.: >
 
 	" Quit Vim immediately after all updates are finished.
-	call minpac#update('', {'do': 'quit'})
+	call minpac#update('', {'do': 'qall'})
 <
 ------------------------------------------------------------------------------
 MAPPINGS					*minpac-mappings*


### PR DESCRIPTION
Issue #148

Using 'quit' shows the following warning:
> warning: minpac progress window not found.

Use 'qall' instead.