### PR TITLE
fix(keymap): add <nowait> to avoid waiting

### DIFF
--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -68,8 +68,8 @@ function! s:syntax() abort
 endfunction
 
 function! s:mappings() abort
-  nnoremap <silent><buffer> q :q<CR>
-  nnoremap <silent><buffer> s :call minpac#status()<CR>
+  nnoremap <silent><buffer><nowait> q :q<CR>
+  nnoremap <silent><buffer><nowait> s :call minpac#status()<CR>
 endfunction
 
 " vim: set ts=8 sw=2 et:

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -138,10 +138,10 @@ function! s:syntax() abort
 endfunction
 
 function! s:mappings() abort
-  nnoremap <silent><buffer> <CR> :call <SID>openSha()<CR>
-  nnoremap <silent><buffer> q :q<CR>
-  nnoremap <silent><buffer> <C-j> :call <SID>nextPackage()<CR>
-  nnoremap <silent><buffer> <C-k> :call <SID>prevPackage()<CR>
+  nnoremap <silent><buffer><nowait> <CR> :call <SID>openSha()<CR>
+  nnoremap <silent><buffer><nowait> q :q<CR>
+  nnoremap <silent><buffer><nowait> <C-j> :call <SID>nextPackage()<CR>
+  nnoremap <silent><buffer><nowait> <C-k> :call <SID>prevPackage()<CR>
 endfunction
 
 function! s:nextPackage() abort


### PR DESCRIPTION
Hi, 

This PR adds `<nowait>` for each keymap to avoid waiting after press `q` or `s` if some keymaps starting with `q` or `s` are set globally. 

For me, I set a keymap `nnoremap qq <Cmd>q<CR>`, `nnoremap qt <Cmd>tabclose<CR>`, and etc. So in the progress window or status window, when I press `q` to quit the window, I have to wait a while to quit. Using `<nowait>` to eliminate this waiting. 

Thank you very much.