### PR TITLE
Merge 'devel' into 'master'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,6 @@ jobs:
           # FIXME: Neovim doesn't work on Ubuntu. Disable it for now.
           - vim_type: 'Neovim'
             os: 'ubuntu-latest'
-          # FIXME: Oldest vim doesn't work on macOS. Disable it for now.
-          - vim_type: 'Vim'
-            version: 'oldest'
-            os: 'mac-latest'
 
     runs-on: '${{ matrix.os }}'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,10 @@ jobs:
           # FIXME: Neovim doesn't work on Ubuntu. Disable it for now.
           - vim_type: 'Neovim'
             os: 'ubuntu-latest'
+          # FIXME: Oldest vim doesn't work on macOS. Disable it for now.
+          - vim_type: 'Vim'
+            version: 'oldest'
+            os: 'mac-latest'
 
     runs-on: '${{ matrix.os }}'
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Build status](https://github.com/k-takata/minpac/workflows/CI/badge.svg)](https://github.com/k-takata/minpac/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/qakftqoyx5m47ns3/branch/master?svg=true)](https://ci.appveyor.com/project/k-takata/minpac/branch/master)
 
-minpac: A minimal package manager for Vim 8 (and Neovim)
-========================================================
+minpac: A minimal package manager for Vim 8+ (and Neovim)
+=========================================================
 
 Overview
 --------
 
-Minpac is a minimal package manager for Vim 8 (and Neovim). This uses the
+Minpac is a minimal package manager for Vim 8+ (and Neovim). This uses the
 [packages](http://vim-jp.org/vimdoc-en/repeat.html#packages) feature and
 the [jobs](http://vim-jp.org/vimdoc-en/channel.html#job-channel-overview)
 feature which have been newly added on Vim 8.

--- a/README.md
+++ b/README.md
@@ -493,6 +493,10 @@ List of mappings available only in status window.
 |`<C-k>`  | Jump to previous package in list. |
 |`q`      | Exit the status window.<br/>(Also works for commit preview window) |
 
+The mappings for `<C-j>` and `<C-k>` can be disabled with:
+```vim
+let g:no_minpac_maps = 1
+```
 
 Similar projects
 ----------------

--- a/README.md
+++ b/README.md
@@ -403,6 +403,13 @@ Otherwise, shows the status of the plugin and commits of last update (if any).
 |----------|-------------|
 | `'open'` | Specify how to open the status window.<br/>`'vertical'`: Open in vertical split.<br/>`'horizontal'`: Open in horizontal split.<br/>`'tab'`: Open in a new tab.<br/>Default: `'horizontal'` or specified value by `minpac#init()`.  |
 
+#### minpac#abort()
+
+Abort updating the plugins. Mainly for debugging.
+
+If you face any errors while running `minpac#update()` and you cannot run it again, you can try this.
+
+
 ### Hooks
 
 Currently, minpac supports two types of hook: Post-update hooks and Finish-update hooks.

--- a/autoload/minpac.vim
+++ b/autoload/minpac.vim
@@ -144,4 +144,9 @@ function! minpac#getpluglist()
   return g:minpac#pluglist
 endfunction
 
+" Abort updating the plugins.
+function! minpac#abort()
+  return minpac#impl#abort()
+endfunction
+
 " vim: set ts=8 sw=2 et:

--- a/autoload/minpac.vim
+++ b/autoload/minpac.vim
@@ -1,5 +1,5 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
 " Last Change:  2020-08-22

--- a/autoload/minpac/git.vim
+++ b/autoload/minpac/git.vim
@@ -1,5 +1,5 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
 " Last Change:  2020-02-01

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -1,8 +1,8 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
-" Last Change:  2020-08-22
+" Last Change:  2023-12-20
 " License:      VIM License
 " URL:          https://github.com/k-takata/minpac
 " ---------------------------------------------------------------------

--- a/autoload/minpac/impl.vim
+++ b/autoload/minpac/impl.vim
@@ -726,4 +726,17 @@ function! minpac#impl#is_update_ran() abort
   return exists('s:installed_plugins')
 endfunction
 
+function! minpac#impl#abort() abort
+  let s:jobqueue = []
+  for l:job in s:joblist
+    call minpac#job#stop(l:job)
+  endfor
+  let s:joblist = []
+  let s:remain_plugins = 0
+  if s:timer_id != -1
+    call timer_stop(s:timer_id)
+    let s:timer_id = -1
+  endif
+endfunction
+
 " vim: set ts=8 sw=2 et:

--- a/autoload/minpac/progress.vim
+++ b/autoload/minpac/progress.vim
@@ -1,5 +1,5 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
 " Last Change:  2020-01-28

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -140,8 +140,10 @@ endfunction
 function! s:mappings() abort
   nnoremap <silent><buffer><nowait> <CR> :call <SID>openSha()<CR>
   nnoremap <silent><buffer><nowait> q :q<CR>
-  nnoremap <silent><buffer><nowait> <C-j> :call <SID>nextPackage()<CR>
-  nnoremap <silent><buffer><nowait> <C-k> :call <SID>prevPackage()<CR>
+  if !exists("no_plugin_maps") && !exists("no_minpac_maps")
+    nnoremap <silent><buffer><nowait> <C-j> :call <SID>nextPackage()<CR>
+    nnoremap <silent><buffer><nowait> <C-k> :call <SID>prevPackage()<CR>
+  endif
 endfunction
 
 function! s:nextPackage() abort

--- a/autoload/minpac/status.vim
+++ b/autoload/minpac/status.vim
@@ -1,5 +1,5 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
 " Created By:   Kristijan Husak

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -608,5 +608,8 @@ List of mappings available only in status window.
 q                       Exit the status window.
                         (Also works for commit preview window)
 
+The mappings for <C-j> and <C-k> can be disabled with: >
+	let g:no_minpac_maps = 1
+
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -1,4 +1,4 @@
-*minpac.txt*	A minimal package manager for Vim 8 (and Neovim)
+*minpac.txt*	A minimal package manager for Vim 8+ (and Neovim)
 
 Version:	3.0.0
 Author:		Ken Takata
@@ -23,7 +23,7 @@ USAGE				|minpac-usage|
 ==============================================================================
 OVERVIEW					*minpac-overview*
 
-Minpac is a minimal package manager for Vim 8 (and Neovim).  This uses the
+Minpac is a minimal package manager for Vim 8+ (and Neovim).  This uses the
 |packages| feature and the jobs feature (|job-channel-overview|) which have
 been newly added on Vim 8.
 

--- a/doc/minpac.txt
+++ b/doc/minpac.txt
@@ -481,6 +481,7 @@ minpac#getpackages([{packname}[, {packtype}[, {plugname}[, {nameonly}]]]])
 	" List package names.
 	echo minpac#getpackages("", "NAME", "", 1)
 <
+
 minpac#status([{config}])			*minpac#status()*
 	Print status of plugins.
 	When ran after |minpac#update()|, shows only installed and updated
@@ -496,6 +497,14 @@ minpac#status([{config}])			*minpac#status()*
 				"tab": Open in a new tab.
 				Default: "horizontal" or specified value by
 				|minpac#init()|.
+
+
+minpac#abort()					*minpac#abort()*
+	Abort updating the plugins. Mainly for debugging.
+
+	If you face any errors while running |minpac#update()| and you cannot
+	run it again, you can try this.
+
 
 ------------------------------------------------------------------------------
 HOOKS						*minpac-hooks*

--- a/plugin/minpac.vim
+++ b/plugin/minpac.vim
@@ -1,5 +1,5 @@
 " ---------------------------------------------------------------------
-" minpac: A minimal package manager for Vim 8 (and Neovim)
+" minpac: A minimal package manager for Vim 8+ (and Neovim)
 "
 " Maintainer:   Ken Takata
 " Last Change:  2020-08-22


### PR DESCRIPTION
* Avoid recursive call in timer callback (https://github.com/vim/vim/issues/13732)
* Use better function/variable names
* Implement `minpac#abort()`
* Disable <C-j> and <C-k> mappings when `g:no_minpac_maps` is defined. (Close #140)